### PR TITLE
Return instructions that weren't partitioned separately

### DIFF
--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -6,6 +6,16 @@ CREATE TABLE transactions (
   transaction BYTEA
 );
 
+CREATE TABLE partition_failures (
+  program_key BYTEA NOT NULL,
+  slot BIGINT NOT NULL,
+  block_index BIGINT NOT NULL,
+  outer_index BIGINT NOT NULL,
+  inner_index BIGINT,
+  signature BYTEA NOT NULL,
+  instruction BYTEA
+);
+
 CREATE TABLE partitions (
   partition_key BYTEA NOT NULL,
   program_key BYTEA NOT NULL,

--- a/scripts/drop_schema.sql
+++ b/scripts/drop_schema.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS bonbons;
 
 DROP TABLE IF EXISTS account_keys;
 DROP TABLE IF EXISTS partitions ;
+DROP TABLE IF EXISTS partition_failures ;
 DROP TABLE IF EXISTS transactions ;
 
 DROP TYPE IF EXISTS limited_edition;


### PR DESCRIPTION
Instead of failing the transaction or silently dropping them